### PR TITLE
Update GitHub Actions runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/vcpkg-action.yml
+++ b/.github/workflows/vcpkg-action.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, windows-2019, ubuntu-latest, ubuntu-22.04, ubuntu-20.04, macos-latest, macos-13]
+        os: [windows-latest, windows-2019, ubuntu-latest, ubuntu-22.04, ubuntu-22.04, macos-latest, macos-13]
 
     steps:
       - name: Checkout

--- a/.github/workflows/vcpkg-action.yml
+++ b/.github/workflows/vcpkg-action.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, windows-2019, ubuntu-latest, ubuntu-22.04, ubuntu-22.04, macos-latest, macos-13]
+        os: [windows-2019, windows-2022, ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm, macos-13, macos-14]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR updates the GitHub Actions runner from ubuntu-20.04 to ubuntu-22.04.